### PR TITLE
Optionally encrypt SNS topic

### DIFF
--- a/security-hub-email-summary-cf-template.json
+++ b/security-hub-email-summary-cf-template.json
@@ -27,6 +27,11 @@
         "AdditionalEmailFooterText": {
                 "Description": "Additional text to append at the end of email message.",
                 "Type": "String"
+            },
+        "KmsKeyId": {
+              "Description": "KMS key ARN to be used for SNS topic encryption. Check out KMS console to find the default key or create a new one.",
+              "Type": "String",
+              "Default": ""
             }
         },
         "Metadata": {
@@ -43,6 +48,14 @@
                             "RecurringScheduleCron",
                             "AdditionalEmailFooterText"
                         ]
+                    },
+                    {
+                      "Label": {
+                          "default": "Recommended"
+                      },
+                      "Parameters": [
+                          "KmsKeyId"
+                      ]
                     }
                 ],
                 "ParameterLabels" : {
@@ -50,7 +63,8 @@
                     "S3KeyName": {"default": "S3 Key Name (with Prefix):"},
                     "RecurringScheduleCron": {"default": "CloudWatch Cron Expression:"},
                     "EmailAddress": {"default": "Email address:"},
-                    "AdditionalEmailFooterText": {"default": "Additional Footer text:"}
+                    "AdditionalEmailFooterText": {"default": "Additional Footer text:"},
+                    "KmsKeyId": {"default": "SNS Topic encryption key:"}
             }
         }},
         "Resources" : {
@@ -62,7 +76,8 @@
                 "Subscription" : [{
                     "Endpoint" : { "Ref" : "EmailAddress" },
                     "Protocol" : "email"
-                  }]
+                  }],
+                "KmsMasterKeyId": {"Fn::If": ["IsKmsKeyIdProvided", {"Ref": "KmsKeyId"}, {"Ref": "AWS::NoValue"}]}
               }
             },
             "SecurityHubSummaryEmailSchedule": {
@@ -359,5 +374,8 @@
                 "insightID" : "6"
             }
         }
+    },
+    "Conditions": {
+      "IsKmsKeyIdProvided": {"Fn::Not": [{"Fn::Equals": [{"Ref": "KmsKeyId"}, ""]}]}
     }
 }


### PR DESCRIPTION
*Issue #1:*
SNS topic does not meet AWS Foundational Security Best Practices standard's requirement [[SNS.1] SNS topics should be encrypted at rest using AWS KMS](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-sns-1).

*Description of changes:*
Optionally, allow providing ARN of AWS KMS key. If key ARN provided, configure the SNS topic to enable encryption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.