### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/security-hub-email-summary-cf-template.json
+++ b/security-hub-email-summary-cf-template.json
@@ -251,7 +251,7 @@
                     "S3Bucket": {"Ref": "S3BucketName"},
                     "S3Key": {"Ref": "S3KeyName"}
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler":"index.lambda_handler",
                 "Timeout": "30",
                 "Environment": {


### PR DESCRIPTION
CloudFormation templates in aws-security-hub-summary-email have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.